### PR TITLE
calculate completing position when set bean list

### DIFF
--- a/stepview/src/main/java/com/baoyachi/stepview/HorizontalStepView.java
+++ b/stepview/src/main/java/com/baoyachi/stepview/HorizontalStepView.java
@@ -67,6 +67,18 @@ public class HorizontalStepView extends LinearLayout implements HorizontalStepsV
     {
         mStepBeanList = stepsBeanList;
         mStepsViewIndicator.setStepNum(mStepBeanList);
+
+        // calculate completing position
+        if (mStepBeanList != null && mStepBeanList.size() > 0) {
+            for (int i = 0; i < mStepBeanList.size(); i++) {
+                StepBean stepsBean = mStepBeanList.get(i);
+                {
+                    if (stepsBean.getState() == StepBean.STEP_COMPLETED) {
+                        mComplectingPosition = i;
+                    }
+                }
+            }
+        }
         return this;
     }
 


### PR DESCRIPTION
It should change mComplectingPosition of HorizontalStepView when setting the bean list, in order to draw text with different formats according to status.